### PR TITLE
fix(infra): Phase 3 - API response types, middleware & instrumentation

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,8 +1,13 @@
 import * as Sentry from '@sentry/nextjs';
 
+// Define proper types for E2E detection
+interface E2EWindow extends Window {
+  __E2E__?: boolean;
+}
+
 // E2E guard
 const E2E =
-  (typeof window !== 'undefined' && (window as any).__E2E__ === true) ||
+  (typeof window !== 'undefined' && (window as E2EWindow).__E2E__ === true) ||
   process.env.NEXT_PUBLIC_E2E === 'true';
 
 // PostHog configuration with basic features
@@ -11,11 +16,14 @@ if (
   typeof window !== 'undefined' &&
   process.env.NEXT_PUBLIC_POSTHOG_KEY
 ) {
+  // Handle the promise properly
   import('posthog-js').then((posthog) => {
     posthog.default.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
       api_host:
         process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com',
     });
+  }).catch(() => {
+    // Silent fail for PostHog initialization
   });
 }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,31 @@
 import posthog from 'posthog-js';
 
+// Define proper types for analytics properties
+export interface AnalyticsProperties {
+  [key: string]: string | number | boolean | undefined;
+}
+
+export interface UserProperties {
+  fullName?: string;
+  email?: string;
+  [key: string]: string | number | boolean | undefined;
+}
+
+export interface PerformanceMetrics {
+  page_load_time?: number;
+  dom_content_loaded?: number;
+  first_paint?: number;
+  first_contentful_paint?: number;
+  timestamp: string;
+  environment: string;
+}
+
+export interface SessionMetrics {
+  distinct_id?: string;
+  timestamp: string;
+  environment: string;
+}
+
 /**
  * Enhanced Analytics Service with PostHog integration
  * Provides comprehensive tracking capabilities for user behavior, performance, and business metrics
@@ -25,12 +51,12 @@ export class AnalyticsService {
   /**
    * Identify a user with PostHog
    */
-  identify(userId: string, properties?: Record<string, any>): void {
+  identify(userId: string, properties?: AnalyticsProperties): void {
     if (!this.checkInitialization()) return;
 
     try {
       posthog.identify(userId, properties);
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -38,14 +64,14 @@ export class AnalyticsService {
   /**
    * Set user properties
    */
-  setUserProperties(properties: Record<string, any>): void {
+  setUserProperties(properties: UserProperties): void {
     if (!this.checkInitialization()) return;
 
     try {
       if (posthog.people) {
         posthog.people.set(properties);
       }
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -53,7 +79,7 @@ export class AnalyticsService {
   /**
    * Track a custom event
    */
-  track(eventName: string, properties?: Record<string, any>): void {
+  track(eventName: string, properties?: AnalyticsProperties): void {
     if (!this.checkInitialization()) return;
 
     try {
@@ -62,7 +88,7 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       });
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -70,7 +96,7 @@ export class AnalyticsService {
   /**
    * Track page view
    */
-  trackPageView(path: string, properties?: Record<string, any>): void {
+  trackPageView(path: string, properties?: AnalyticsProperties): void {
     if (!this.checkInitialization()) return;
 
     try {
@@ -80,7 +106,7 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       });
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -93,7 +119,7 @@ export class AnalyticsService {
   trackPerformance(
     metricName: string,
     value: number,
-    properties?: Record<string, any>
+    properties?: AnalyticsProperties
   ): void {
     if (!this.checkInitialization()) return;
 
@@ -105,7 +131,7 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       });
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -113,7 +139,7 @@ export class AnalyticsService {
   /**
    * Track errors
    */
-  trackError(error: Error, context?: Record<string, any>): void {
+  trackError(error: Error, context?: AnalyticsProperties): void {
     if (!this.checkInitialization()) return;
 
     try {
@@ -125,7 +151,7 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       });
-    } catch (trackingError) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -133,7 +159,7 @@ export class AnalyticsService {
   /**
    * Track user actions
    */
-  trackUserAction(action: string, properties?: Record<string, any>): void {
+  trackUserAction(action: string, properties?: AnalyticsProperties): void {
     if (!this.checkInitialization()) return;
 
     try {
@@ -143,7 +169,7 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       });
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -151,7 +177,7 @@ export class AnalyticsService {
   /**
    * Track session start
    */
-  trackSessionStart(properties?: Record<string, any>): void {
+  trackSessionStart(properties?: AnalyticsProperties): void {
     if (!this.checkInitialization()) return;
 
     try {
@@ -160,7 +186,7 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       });
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -168,7 +194,7 @@ export class AnalyticsService {
   /**
    * Track session end
    */
-  trackSessionEnd(properties?: Record<string, any>): void {
+  trackSessionEnd(properties?: AnalyticsProperties): void {
     if (!this.checkInitialization()) return;
 
     try {
@@ -177,7 +203,7 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       });
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -185,7 +211,7 @@ export class AnalyticsService {
   /**
    * Track form interactions
    */
-  trackFormStart(formName: string, properties?: Record<string, any>): void {
+  trackFormStart(formName: string, properties?: AnalyticsProperties): void {
     if (!this.checkInitialization()) return;
 
     try {
@@ -195,7 +221,7 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       });
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -206,7 +232,7 @@ export class AnalyticsService {
   trackFormSubmit(
     formName: string,
     success: boolean,
-    properties?: Record<string, any>
+    properties?: AnalyticsProperties
   ): void {
     if (!this.checkInitialization()) return;
 
@@ -218,7 +244,7 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       });
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -229,7 +255,7 @@ export class AnalyticsService {
   trackNavigation(
     from: string,
     to: string,
-    properties?: Record<string, any>
+    properties?: AnalyticsProperties
   ): void {
     if (!this.checkInitialization()) return;
 
@@ -241,7 +267,7 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       });
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -252,7 +278,7 @@ export class AnalyticsService {
   trackSearch(
     query: string,
     resultsCount?: number,
-    properties?: Record<string, any>
+    properties?: AnalyticsProperties
   ): void {
     if (!this.checkInitialization()) return;
 
@@ -264,7 +290,7 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       });
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -272,8 +298,11 @@ export class AnalyticsService {
   /**
    * Get session metrics
    */
-  getSessionMetrics(): Record<string, any> {
-    if (!this.checkInitialization()) return {};
+  getSessionMetrics(): SessionMetrics {
+    if (!this.checkInitialization()) return {
+      timestamp: new Date().toISOString(),
+      environment: process.env.NODE_ENV || 'development',
+    };
 
     try {
       return {
@@ -281,17 +310,23 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       };
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
-      return {};
+      return {
+        timestamp: new Date().toISOString(),
+        environment: process.env.NODE_ENV || 'development',
+      };
     }
   }
 
   /**
    * Get performance metrics
    */
-  getPerformanceMetrics(): Record<string, any> {
-    if (!this.checkInitialization()) return {};
+  getPerformanceMetrics(): PerformanceMetrics {
+    if (!this.checkInitialization()) return {
+      timestamp: new Date().toISOString(),
+      environment: process.env.NODE_ENV || 'development',
+    };
 
     try {
       const navigation = performance.getEntriesByType(
@@ -310,9 +345,12 @@ export class AnalyticsService {
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
       };
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
-      return {};
+      return {
+        timestamp: new Date().toISOString(),
+        environment: process.env.NODE_ENV || 'development',
+      };
     }
   }
 
@@ -324,7 +362,7 @@ export class AnalyticsService {
 
     try {
       posthog.reset();
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -337,7 +375,7 @@ export class AnalyticsService {
 
     try {
       posthog.opt_out_capturing();
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }
@@ -350,7 +388,7 @@ export class AnalyticsService {
 
     try {
       posthog.opt_in_capturing();
-    } catch (error) {
+    } catch {
       // Silent fail for analytics
     }
   }

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -8,6 +8,11 @@ export type SessionUser = {
   role: string;
 };
 
+// Define proper error type with status code
+export interface AuthError extends Error {
+  statusCode: number;
+}
+
 function extractFromUnknown<T>(value: unknown, key: string): T | undefined {
   if (
     value &&
@@ -50,8 +55,8 @@ export async function getOrganisationIdFromSession(): Promise<string> {
 export async function requireSystemPermission(permissionId: PermissionId) {
   const { role } = await getSessionUser();
   if (!hasPermission(role, permissionId, undefined, true)) {
-    const error = new Error('Forbidden');
-    (error as any).statusCode = 403;
+    const error = new Error('Forbidden') as AuthError;
+    error.statusCode = 403;
     throw error;
   }
   return true as const;
@@ -65,8 +70,8 @@ export async function requireOrgPermission(
   const targetOrgId = organisationId || userOrgId;
 
   if (!hasPermission(role, permissionId, targetOrgId, false)) {
-    const error = new Error('Forbidden');
-    (error as any).statusCode = 403;
+    const error = new Error('Forbidden') as AuthError;
+    error.statusCode = 403;
     throw error;
   }
   return true as const;
@@ -110,7 +115,7 @@ export async function requirePermissionWithRedirect(
     }
   } catch (error) {
     // If it's a 403 error, redirect to unauthorized page
-    if ((error as any).statusCode === 403) {
+    if ((error as AuthError).statusCode === 403) {
       redirect(redirectTo);
     }
     // Re-throw other errors

--- a/src/lib/feature-flags/auth-integration.ts
+++ b/src/lib/feature-flags/auth-integration.ts
@@ -2,8 +2,15 @@
 import { statsigAdapter, type StatsigUser } from '@flags-sdk/statsig';
 import { FeatureFlags } from './types';
 
+// Define proper user type
+export interface FeatureFlagUser {
+  id: string;
+  fullName?: string;
+  emailAddresses?: Array<{ emailAddress: string }>;
+}
+
 // Identify user in Statsig for feature flags
-export async function identifyUserForFeatureFlags(user: any): Promise<void> {
+export async function identifyUserForFeatureFlags(user: FeatureFlagUser): Promise<void> {
   try {
     if (!user) return;
 
@@ -26,7 +33,7 @@ export async function identifyUserForFeatureFlags(user: any): Promise<void> {
 }
 
 // Bootstrap feature flags for a user
-export async function bootstrapFeatureFlags(user: any): Promise<void> {
+export async function bootstrapFeatureFlags(user: FeatureFlagUser): Promise<void> {
   try {
     if (!user) return;
 

--- a/src/lib/feature-flags/client.ts
+++ b/src/lib/feature-flags/client.ts
@@ -4,7 +4,7 @@ import type { FeatureFlags } from './types';
 
 export interface FeatureFlagResult {
   enabled: boolean;
-  value?: any;
+  value?: string | number | boolean;
 }
 
 // Get current user details for Statsig identification
@@ -30,7 +30,7 @@ export async function getFeatureFlag(
       enabled,
       value: undefined,
     };
-  } catch (error) {
+  } catch {
     // Default to disabled if there's an error
     return {
       enabled: false,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -140,7 +140,7 @@ export default clerkMiddleware(async (auth, req) => {
             subject: userId,
           });
           hasCompletedOnboarding = Boolean(user?.onboardingCompleted);
-        } catch (convexErr) {
+        } catch {
           // Non-fatal; proceed with claims-only decision
         }
       }
@@ -157,7 +157,7 @@ export default clerkMiddleware(async (auth, req) => {
               }
             )?.publicMetadata?.onboardingCompleted
           );
-        } catch (clerkErr) {
+        } catch {
           // Clerk live metadata check failed
         }
       }
@@ -172,7 +172,7 @@ export default clerkMiddleware(async (auth, req) => {
         const dashboardUrl = new URL('/dashboard', req.url);
         return NextResponse.redirect(dashboardUrl);
       }
-    } catch (error) {
+    } catch {
       // Allow access if check fails unexpectedly
     }
   }

--- a/src/sanity/lib/client.ts
+++ b/src/sanity/lib/client.ts
@@ -2,6 +2,11 @@ import { createClient } from 'next-sanity';
 
 import { apiVersion, dataset, projectId, sanityEnabled } from '../env';
 
+// Define proper types for the mock client
+interface MockSanityClient {
+  fetch: () => Promise<never[]>;
+}
+
 export const client = sanityEnabled
   ? createClient({
       projectId,
@@ -10,7 +15,7 @@ export const client = sanityEnabled
       useCdn: true,
     })
   : ({
-      fetch: async () => {
-        return [] as any;
+      fetch: async (): Promise<never[]> => {
+        return [];
       },
-    } as unknown as ReturnType<typeof createClient>);
+    } as MockSanityClient);

--- a/src/sanity/lib/image.ts
+++ b/src/sanity/lib/image.ts
@@ -3,6 +3,14 @@ import type { SanityImageSource } from '@sanity/image-url/lib/types/types';
 
 import { dataset, projectId, sanityEnabled } from '../env';
 
+// Define proper types for the mock image builder
+interface MockImageBuilder {
+  width: () => MockImageBuilder;
+  height: () => MockImageBuilder;
+  fit: () => MockImageBuilder;
+  url: () => string;
+}
+
 // https://www.sanity.io/docs/image-url
 const builder = sanityEnabled
   ? createImageUrlBuilder({ projectId, dataset })
@@ -10,12 +18,13 @@ const builder = sanityEnabled
 
 export const urlFor = (source: SanityImageSource) => {
   if (!builder) {
-    return {
-      width: () => ({ height: () => ({ fit: () => ({ url: () => '' }) }) }),
-      height: () => ({ fit: () => ({ url: () => '' }) }),
-      fit: () => ({ url: () => '' }),
+    const mockBuilder: MockImageBuilder = {
+      width: () => mockBuilder,
+      height: () => mockBuilder,
+      fit: () => mockBuilder,
       url: () => '',
-    } as any;
+    };
+    return mockBuilder;
   }
   return builder.image(source);
 };


### PR DESCRIPTION
- src/lib/analytics.ts: Replace all 'any' types with proper interfaces, remove unused error variables
- src/lib/authz.ts: Replace 'any' types with proper AuthError interface, improve error handling
- src/middleware.ts: Remove unused error variables, improve type safety
- src/instrumentation-client.ts: Replace 'any' types with proper E2EWindow interface, fix promise handling
- src/lib/feature-flags/auth-integration.ts: Replace 'any' types with FeatureFlagUser interface
- src/lib/feature-flags/client.ts: Replace 'any' types with proper return types, improve error handling
- src/sanity/lib/client.ts: Replace 'any' types with MockSanityClient interface
- src/sanity/lib/image.ts: Replace 'any' types with MockImageBuilder interface

All Phase 3 files now have explicit, accurate types with no 'any' in public function signatures. Middleware and instrumentation pass lint successfully.

Closes #8 