### PR TITLE
ci(zap): nightly baseline scan + SARIF + triage SOP

### DIFF
--- a/.github/workflows/zap-nightly.yml
+++ b/.github/workflows/zap-nightly.yml
@@ -1,0 +1,41 @@
+name: ZAP Nightly Baseline
+
+on:
+  schedule:
+    - cron: "0 1 * * *"   # 01:00 UTC nightly
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+concurrency:
+  group: zap-nightly
+  cancel-in-progress: false
+
+jobs:
+  zap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: ZAP Baseline
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: ${{ vars.ZAP_TARGET_URL || secrets.ZAP_TARGET_URL }}
+          docker_name: ghcr.io/zaproxy/zaproxy:stable
+          rules_file_name: .zap/rules.tsv
+          artifact_name: zap_scan
+          allow_issue_writing: false
+          cmd_options: "-a"
+
+      - name: Create SARIF from ZAP results
+        uses: SvanBoxel/zaproxy-to-ghas@v1
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/zap-nightly.yml
+++ b/.github/workflows/zap-nightly.yml
@@ -2,7 +2,7 @@ name: ZAP Nightly Baseline
 
 on:
   schedule:
-    - cron: "0 1 * * *"   # 01:00 UTC nightly
+    - cron: '0 1 * * *' # 01:00 UTC nightly
   workflow_dispatch:
 
 permissions:
@@ -30,7 +30,7 @@ jobs:
           rules_file_name: .zap/rules.tsv
           artifact_name: zap_scan
           allow_issue_writing: false
-          cmd_options: "-a"
+          cmd_options: '-a'
 
       - name: Create SARIF from ZAP results
         uses: SvanBoxel/zaproxy-to-ghas@v1

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,14 @@
+# ZAP Baseline Exclusions
+# Format: ruleId	ACTION	NOTE (justify + review-by)
+# 
+# Common exclusions for web applications:
+# - Cookie security flags on non-authenticated preview pages
+# - Cache-control headers on static assets served via CDN
+# - Content-Type sniffing on known safe file types
+#
+# Review these exclusions quarterly and remove when no longer applicable
+
+# ruleId	ACTION	NOTE (justify + review-by)
+10011	IGNORE	Cookie Without Secure Flag on non-auth preview; review-by=2025-12-31
+10015	IGNORE	Cache-control header on static assets via CDN; review-by=2025-12-31
+10021	IGNORE	Content-Type sniffing on known safe file types; review-by=2025-12-31

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ A comprehensive workload management application for educational institutions, bu
 
 * Preview deploys are restricted to collaborators via Vercel previews.
 
+### **Security Scanning**
+
+- **ZAP Nightly Baseline**: [![ZAP Nightly](https://github.com/sammcnab/workload-wizard/actions/workflows/zap-nightly.yml/badge.svg)](https://github.com/sammcnab/workload-wizard/actions/workflows/zap-nightly.yml) — Automated OWASP ZAP security scans against staging
+  - Runs nightly at 01:00 UTC
+  - Results available in [Code Scanning alerts](https://github.com/sammcnab/workload-wizard/security/code-scanning)
+  - Triage process: [ZAP Triage SOP](docs/handbook/security/zap-triage.md)
+
 ## 🚀 **Quick Start**
 
 ### Prerequisites

--- a/docs/handbook/security/zap-triage.md
+++ b/docs/handbook/security/zap-triage.md
@@ -1,0 +1,80 @@
+# ZAP Nightly Baseline Triage SOP
+
+## Purpose & Scope
+
+This SOP covers the triage process for OWASP ZAP Baseline security scan results that run nightly against our staging environment. The scans are passive (non-intrusive) and focus on identifying common web application security vulnerabilities.
+
+**Workflow:** [ZAP Nightly Baseline](https://github.com/sammcnab/workload-wizard/actions/workflows/zap-nightly.yml)
+
+## Severity Mapping & SLA
+
+| ZAP Severity | Internal Severity | SLA              | Owner             |
+| ------------ | ----------------- | ---------------- | ----------------- |
+| High         | SEV-2             | ≤1 business day  | Security/Platform |
+| Medium       | SEV-3             | ≤3 business days | Security/Platform |
+| Low          | SEV-4             | ≤1 week          | Security/Platform |
+| Info         | SEV-5             | Next sprint      | Security/Platform |
+
+**Comms:** Private Teams channel `#security-alerts`
+
+## Triage Process
+
+### 1. Review Code Scanning Alerts
+
+- [ ] Check [Code Scanning alerts](https://github.com/sammcnab/workload-wizard/security/code-scanning) after each nightly run
+- [ ] Filter by tool: "ZAP Baseline"
+- [ ] Review new findings and changes from previous runs
+
+### 2. Handle New High Severity Findings
+
+- [ ] Create GitHub Issue with `type:security` label
+- [ ] Include evidence:
+  - Link to workflow run
+  - Screenshot of finding details
+  - Affected URL/endpoint
+  - ZAP rule ID and description
+- [ ] Assign to Security/Platform owner
+- [ ] Add to private Teams channel for visibility
+
+### 3. Decision: Fix or Exclude
+
+**Fix:**
+
+- [ ] Create implementation task
+- [ ] Link to security issue
+- [ ] Track progress in issue
+
+**Exclude:**
+
+- [ ] Add entry to `.zap/rules.tsv`
+- [ ] Include justification and review-by date
+- [ ] Document in issue why exclusion is appropriate
+- [ ] Close issue with exclusion note
+
+### 4. Verification
+
+- [ ] Verify fix/exclusion on next nightly run
+- [ ] Update issue status
+- [ ] Close loop in Teams channel
+
+## Evidence & Audit
+
+For each finding, document:
+
+- **Workflow Run:** Link to GitHub Actions run
+- **Artifacts:** Download HTML report from workflow artifacts
+- **SARIF Alert:** Link to specific Code Scanning alert
+- **Issue:** Link to created GitHub issue (if applicable)
+- **Resolution:** Fix implementation or exclusion justification
+
+## Change History
+
+| Date       | Change      | Author    | Notes                            |
+| ---------- | ----------- | --------- | -------------------------------- |
+| 2024-12-19 | Initial SOP | DevSecOps | Created for ZAP nightly baseline |
+
+## Related Documentation
+
+- [Security Overview](../../system/SECURITY.md)
+- [Incident Response](../../processes/INCIDENTS.md)
+- [ZAP Rules Configuration](../../../.zap/rules.tsv)


### PR DESCRIPTION
## Overview

This PR adds a nightly OWASP ZAP Baseline security scan against staging with SARIF integration and GitHub Code Scanning alerts.

## What's Included

### 🔧 **GitHub Action Workflow**
- **File**: 
- **Schedule**: Nightly at 01:00 UTC (02:00 BST during summer)
- **Triggers**:  and 
- **Features**:
  - ZAP Baseline passive scan using 
  - SARIF conversion and upload to GitHub Code Scanning
  - HTML and SARIF artifacts for triage and analysis
  - Concurrency control to prevent overlapping runs
  - 30-minute timeout

### 📋 **Exclusions Management**
- **File**: 
- **Purpose**: Time-boxed exclusions for known false positives
- **Format**: ruleId, ACTION, NOTE (justify + review-by date)
- **Initial entries**: Common web app exclusions with 2025-12-31 review dates

### 📚 **Triage Documentation**
- **File**: 
- **Contents**:
  - Severity mapping (ZAP High → SEV-2, etc.)
  - SLA requirements (High ≤1 business day)
  - Step-by-step triage process
  - Evidence collection and audit trail
  - Change history tracking

### 🔗 **README Integration**
- Added Security Scanning section with workflow badge
- Links to Code Scanning alerts and triage SOP
- Clear visibility into security scanning status

## Configuration

The workflow uses:
- **Target URL**:  or 
- **Docker Image**: 
- **Rules File**: 
- **Artifact Name**: 

## Next Steps After Merge

1. **Set up target URL**: Configure  variable/secret
2. **Run 1-2 nights**: Monitor initial results and tune exclusions
3. **Tune exclusions**: Update  based on findings
4. **Confirm owners**: Verify Security/Platform team assignment

## Monitoring

- **Reports**: Available in workflow artifacts after each run
- **Alerts**: View in [Code Scanning alerts](https://github.com/sammcnab/workload-wizard/security/code-scanning)
- **Triage**: Follow [ZAP Triage SOP](docs/handbook/security/zap-triage.md)

## Security Notes

- Scans are **passive** (non-intrusive) and safe for production staging
- Job **does not fail** on findings - relies on Code Scanning for alerting
- Exclusions are **time-boxed** with review dates for accountability