### PR TITLE
docs(security): index page linking headers/CSP/runbooks/scanning/DR + README TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     - [E2E Tests](#e2e-tests)
     - [Unit Tests](#unit-tests)
   - [📚 **Documentation**](#-documentation)
+  - [🔒 **Security**](#-security)
   - [🔧 **Development**](#-development)
     - [Branching & CI](#branching--ci)
     - [Code Quality](#code-quality)
@@ -205,6 +206,15 @@ pnpm test:watch
 
 - **[Operations Handbook](docs/handbook/operations/README.md)** — Standard Operating Procedures for security, incidents, secret rotation, and CI failures
 - **[Observability Handbook](docs/handbook/observability/README.md)** — Comprehensive guides for monitoring, tracing, dashboards, and alerting
+
+## 🔒 **Security**
+
+- **[Security Overview](docs/engineering/security/_index.md)** — Core security topics and runbooks
+  - **Headers & HTTPS** — HSTS, TLS, referrer-policy, cookies, CORS
+  - **Content Security Policy (CSP)** — Report-only to enforce implementation
+  - **Runbooks** — Vulnerability intake, secret rotation, incident response, CI failure triage
+  - **Scanning** — ZAP nightly baseline, Dependabot/CodeQL alerts
+  - **Disaster Recovery** — DR plan, backups & restore tests
 
 ## 🔧 **Operations**
 

--- a/docs/engineering/security/_index.md
+++ b/docs/engineering/security/_index.md
@@ -1,0 +1,26 @@
+# Security Overview
+
+This index links core security topics for the project. Each page is short, actionable, and owned.
+
+## Quick Links
+
+- **Headers & HTTPS** → [Headers & HTTPS hardening](headers.md) _(HSTS, TLS, referrer-policy, cookies, CORS)_
+- **Content Security Policy (CSP)** → [CSP: report-only to enforce](csp.md)
+- **Runbooks**
+  - [Vulnerability intake & SLAs](../../handbook/operations/sop-vulnerability-intake.md)
+  - [Secret rotation](../../handbook/operations/sop-secret-rotation.md)
+  - [Incident response](../../handbook/operations/sop-incident-response.md)
+  - [CI failure triage](../../handbook/operations/sop-ci-failure-triage.md)
+- **Scanning**
+  - [ZAP nightly baseline & triage](../../handbook/security/zap-triage.md)
+  - [Code scanning (Dependabot/CodeQL)](code-scanning.md)
+- **Disaster Recovery**
+  - [DR plan](../../operations/dr/policy.md)
+  - [Backups & restore tests](../../operations/dr/backups.md)
+
+## Ownership
+
+- **Security owners:** Platform Team
+- **Change control:** changes via PR with CODEOWNERS review.
+
+_Last updated: 2025-01-27_

--- a/docs/engineering/security/code-scanning.md
+++ b/docs/engineering/security/code-scanning.md
@@ -1,0 +1,11 @@
+# Code Scanning (Dependabot/CodeQL)
+
+**Scope:** dependency advisories and static analysis.
+
+## Process
+
+- Dependabot PRs triaged weekly.
+- CodeQL alerts reviewed after each run.
+- For true positives: patch/upgrade; for false positives: document and suppress with justification.
+
+> TODO: Add dashboard links and owners.


### PR DESCRIPTION
## Summary

This PR adds a comprehensive security documentation index that links all core security topics and ensures the ≤2 clicks rule from README to any security topic.

## Changes

### Added Files
- `docs/engineering/security/_index.md` - Main security index with links to all topics
- `docs/engineering/security/code-scanning.md` - Minimal stub for Dependabot/CodeQL guidance

### Updated Files
- `README.md` - Added Security section to TOC and content

## Index Structure

The security index links to:

**1) Headers/HTTPS** → `docs/engineering/security/headers.md` (existing)
**2) CSP** → `docs/engineering/security/csp.md` (existing)  
**3) Runbooks** → All four SOPs in `docs/handbook/operations/` (existing)
**4) Scanning** → `docs/handbook/security/zap-triage.md` + new code-scanning stub
**5) Disaster Recovery** → `docs/operations/dr/policy.md` and `backups.md` (existing)

## Verification

✅ **≤2 clicks rule confirmed**: README → Security → any topic page  
✅ **All relative links resolve** in GitHub UI  
✅ **Existing docs preserved** - only added links, no content moved  
✅ **Minimal stubs created** only where targets were missing  

## Index File Variant

Used `_index.md` as the preferred path for the security index.

## Stubs Created

- `docs/engineering/security/code-scanning.md` - TODO for Dependabot/CodeQL dashboard links and owners

All other target documents already existed and are properly linked.