### PR TITLE
feat(dashboard): responsive workload dashboard with summary cards, status panel and quick links

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,8 +3,8 @@
 // Force dynamic rendering to prevent Clerk authentication errors during build
 export const dynamic = 'force-dynamic';
 
-import { DashboardPlaceholder } from '@/components/common/PlaceholderPage';
+import { DashboardContent } from '@/components/dashboard/DashboardContent';
 
 export default function DashboardPage() {
-  return <DashboardPlaceholder />;
+  return <DashboardContent />;
 }

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useUser } from '@clerk/nextjs';
+import { StandardizedSidebarLayout } from '@/components/layout/StandardizedSidebarLayout';
+import { WorkloadSummaryCards } from '@/components/dashboard/WorkloadSummaryCards';
+import { WorkloadStatusPanel } from '@/components/dashboard/WorkloadStatusPanel';
+import { QuickLinksSection } from '@/components/dashboard/QuickLinksSection';
+import { useAcademicYear } from '@/components/providers/AcademicYearProvider';
+import { Badge } from '@/components/ui/badge';
+import { CalendarDays } from 'lucide-react';
+
+export function DashboardContent() {
+  const { user } = useUser();
+  const { currentYear } = useAcademicYear();
+
+  const greeting = () => {
+    const hour = new Date().getHours();
+    if (hour < 12) return 'Good morning';
+    if (hour < 17) return 'Good afternoon';
+    return 'Good evening';
+  };
+
+  const firstName = user?.firstName ?? user?.username ?? 'there';
+
+  return (
+    <StandardizedSidebarLayout
+      breadcrumbs={[{ label: 'Dashboard' }]}
+      headerActions={
+        currentYear ? (
+          <Badge
+            variant="outline"
+            className="flex items-center gap-1.5 text-xs font-normal"
+          >
+            <CalendarDays className="h-3.5 w-3.5" />
+            {currentYear.name}
+          </Badge>
+        ) : undefined
+      }
+    >
+      <div data-testid="page-ready" />
+
+      {/* Page heading */}
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          {greeting()}, {firstName}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {currentYear
+            ? `Here's an overview of your workload for ${currentYear.name}.`
+            : "Here's an overview of your current workload."}
+        </p>
+      </div>
+
+      {/* Summary stat cards */}
+      <section aria-label="Workload summary">
+        <WorkloadSummaryCards />
+      </section>
+
+      {/* Capacity bars + recent allocations */}
+      <section aria-label="Workload status">
+        <WorkloadStatusPanel />
+      </section>
+
+      {/* Quick links */}
+      <section aria-label="Quick links">
+        <QuickLinksSection />
+      </section>
+    </StandardizedSidebarLayout>
+  );
+}

--- a/src/components/dashboard/QuickLinksSection.tsx
+++ b/src/components/dashboard/QuickLinksSection.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Users,
+  BookOpen,
+  BarChart3,
+  Building2,
+  GraduationCap,
+  ClipboardList,
+  Settings,
+  ShieldCheck,
+  FileText,
+  CalendarDays,
+} from 'lucide-react';
+
+interface QuickLink {
+  label: string;
+  href: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string }>;
+  variant?: 'default' | 'outline' | 'secondary';
+  iconBg: string;
+  iconColor: string;
+}
+
+const QUICK_LINKS: QuickLink[] = [
+  {
+    label: 'My Staff Profile',
+    href: '/staff',
+    description: 'View your teaching profile and allocations',
+    icon: Users,
+    iconBg: 'bg-primary/10',
+    iconColor: 'text-primary',
+  },
+  {
+    label: 'Modules',
+    href: '/modules',
+    description: 'Browse and manage module definitions',
+    icon: BookOpen,
+    iconBg: 'bg-blue-100 dark:bg-blue-900/30',
+    iconColor: 'text-blue-600 dark:text-blue-400',
+  },
+  {
+    label: 'Courses',
+    href: '/courses',
+    description: 'Manage course years and module links',
+    icon: GraduationCap,
+    iconBg: 'bg-indigo-100 dark:bg-indigo-900/30',
+    iconColor: 'text-indigo-600 dark:text-indigo-400',
+  },
+  {
+    label: 'Organisation',
+    href: '/organisation',
+    description: 'Settings, roles and academic years',
+    icon: Building2,
+    iconBg: 'bg-emerald-100 dark:bg-emerald-900/30',
+    iconColor: 'text-emerald-600 dark:text-emerald-400',
+  },
+  {
+    label: 'Academic Years',
+    href: '/organisation/academic-years',
+    description: 'Manage academic year configurations',
+    icon: CalendarDays,
+    iconBg: 'bg-violet-100 dark:bg-violet-900/30',
+    iconColor: 'text-violet-600 dark:text-violet-400',
+  },
+  {
+    label: 'Audit Logs',
+    href: '/organisation/audit-logs',
+    description: 'Review recent system activity',
+    icon: ClipboardList,
+    iconBg: 'bg-orange-100 dark:bg-orange-900/30',
+    iconColor: 'text-orange-600 dark:text-orange-400',
+  },
+  {
+    label: 'Permissions',
+    href: '/admin/permissions',
+    description: 'Manage roles and user permissions',
+    icon: ShieldCheck,
+    iconBg: 'bg-rose-100 dark:bg-rose-900/30',
+    iconColor: 'text-rose-600 dark:text-rose-400',
+  },
+  {
+    label: 'Reports',
+    href: '/admin',
+    description: 'Admin overview and system reports',
+    icon: BarChart3,
+    iconBg: 'bg-cyan-100 dark:bg-cyan-900/30',
+    iconColor: 'text-cyan-600 dark:text-cyan-400',
+  },
+  {
+    label: 'Account Settings',
+    href: '/account',
+    description: 'Profile, security and preferences',
+    icon: Settings,
+    iconBg: 'bg-muted',
+    iconColor: 'text-muted-foreground',
+  },
+  {
+    label: 'Support',
+    href: '/support',
+    description: 'Get help or submit feedback',
+    icon: FileText,
+    iconBg: 'bg-muted',
+    iconColor: 'text-muted-foreground',
+  },
+];
+
+export function QuickLinksSection() {
+  return (
+    <Card>
+      <CardHeader className="pb-4">
+        <CardTitle className="text-base font-semibold">Quick Links</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+          {QUICK_LINKS.map((link) => (
+            <Button
+              key={link.href}
+              variant="outline"
+              asChild
+              className="h-auto justify-start gap-3 px-3 py-3 text-left hover:bg-accent/60 transition-colors"
+            >
+              <Link href={link.href}>
+                <div
+                  className={`flex-shrink-0 rounded-lg p-2 ${link.iconBg}`}
+                >
+                  <link.icon className={`h-4 w-4 ${link.iconColor}`} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-foreground">
+                    {link.label}
+                  </p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {link.description}
+                  </p>
+                </div>
+              </Link>
+            </Button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/WorkloadStatusPanel.tsx
+++ b/src/components/dashboard/WorkloadStatusPanel.tsx
@@ -1,0 +1,445 @@
+'use client';
+
+import { useUser } from '@clerk/nextjs';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { useAcademicYear } from '@/components/providers/AcademicYearProvider';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { CheckCircle2, AlertTriangle, AlertCircle, Info } from 'lucide-react';
+
+type WorkloadStatus = 'optimal' | 'warning' | 'over' | 'unset';
+
+function getStatusMeta(pct: number, hasMax: boolean): {
+  status: WorkloadStatus;
+  label: string;
+  badgeVariant: 'default' | 'secondary' | 'destructive' | 'outline';
+  badgeClass: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  barClass: string;
+} {
+  if (!hasMax) {
+    return {
+      status: 'unset',
+      label: 'No limit set',
+      badgeVariant: 'outline',
+      badgeClass: '',
+      Icon: Info,
+      barClass: 'bg-muted-foreground/30',
+    };
+  }
+  if (pct > 100) {
+    return {
+      status: 'over',
+      label: 'Over capacity',
+      badgeVariant: 'destructive',
+      badgeClass: '',
+      Icon: AlertCircle,
+      barClass: 'bg-destructive',
+    };
+  }
+  if (pct >= 85) {
+    return {
+      status: 'warning',
+      label: 'Near capacity',
+      badgeVariant: 'outline',
+      badgeClass: 'border-amber-400 bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+      Icon: AlertTriangle,
+      barClass: 'bg-amber-500',
+    };
+  }
+  return {
+    status: 'optimal',
+    label: 'On track',
+    badgeVariant: 'outline',
+    badgeClass: 'border-emerald-400 bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+    Icon: CheckCircle2,
+    barClass: 'bg-emerald-500',
+  };
+}
+
+interface CapacityBarProps {
+  label: string;
+  used: number;
+  max: number;
+  colorClass: string;
+  tooltip?: string;
+}
+
+function CapacityBar({ label, used, max, colorClass, tooltip }: CapacityBarProps) {
+  const pct = max > 0 ? Math.min(100, Math.round((used / max) * 100)) : 0;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="space-y-1.5 cursor-default">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground font-medium">{label}</span>
+              <span className="font-semibold text-foreground tabular-nums">
+                {used}h{max > 0 ? ` / ${max}h` : ''}
+              </span>
+            </div>
+            <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className={`h-full rounded-full transition-all duration-700 ease-out ${colorClass}`}
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>{pct}% used</span>
+              {max > 0 && (
+                <span>{Math.max(0, max - used)}h remaining</span>
+              )}
+            </div>
+          </div>
+        </TooltipTrigger>
+        {tooltip && (
+          <TooltipContent>
+            <p className="text-xs">{tooltip}</p>
+          </TooltipContent>
+        )}
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export function WorkloadStatusPanel() {
+  const { user } = useUser();
+  const { currentYear } = useAcademicYear();
+
+  const staffList = useQuery(
+    api.staff.list,
+    user?.id ? { userId: user.id } : 'skip'
+  ) as Array<{
+    _id: string;
+    fullName: string;
+    userSubject?: string;
+    maxTeachingHours?: number;
+    totalContract?: number;
+    contract?: string;
+    fte?: number;
+  }> | undefined;
+
+  const linkedProfile = staffList?.find((s) => s.userSubject === user?.id);
+
+  const totals = useQuery(
+    api.allocations.computeLecturerTotals,
+    linkedProfile?._id && currentYear?._id
+      ? {
+          lecturerId: linkedProfile._id as Id<'lecturer_profiles'>,
+          academicYearId: currentYear._id as Id<'academic_years'>,
+        }
+      : 'skip'
+  ) as
+    | {
+        allocatedTeaching: number;
+        allocatedAdmin: number;
+        allocatedTotal: number;
+      }
+    | undefined;
+
+  const adminAllocations = useQuery(
+    api.allocations.listAdminAllocations,
+    linkedProfile?._id && currentYear?._id
+      ? {
+          lecturerId: linkedProfile._id as Id<'lecturer_profiles'>,
+          academicYearId: currentYear._id as Id<'academic_years'>,
+        }
+      : 'skip'
+  ) as Array<{ allocation?: { hours?: number } }> | undefined;
+
+  const detailedAllocations = useQuery(
+    api.allocations.listForLecturerDetailed,
+    linkedProfile?._id && currentYear?._id
+      ? {
+          lecturerId: linkedProfile._id as Id<'lecturer_profiles'>,
+          academicYearId: currentYear._id as Id<'academic_years'>,
+        }
+      : 'skip'
+  ) as Array<{
+    allocation: { type: string; hoursOverride?: number; hoursComputed?: number };
+    module: { code?: string; name?: string } | null;
+    group: { name?: string } | null;
+  }> | undefined;
+
+  const isLoadingProfile = staffList === undefined;
+  const isLoadingTotals = linkedProfile && totals === undefined;
+  const isLoading = isLoadingProfile || !!isLoadingTotals;
+
+  const teaching = totals?.allocatedTeaching ?? 0;
+  const adminStandalone = (adminAllocations || []).reduce(
+    (acc, r) => acc + (Number(r?.allocation?.hours) || 0),
+    0
+  );
+  const admin = (totals?.allocatedAdmin ?? 0) + adminStandalone;
+  const total = teaching + admin;
+  const maxTeaching = Number(linkedProfile?.maxTeachingHours) || 0;
+  const maxTotal = Number(linkedProfile?.totalContract) || 0;
+
+  const teachingPct = maxTeaching > 0 ? Math.round((teaching / maxTeaching) * 100) : 0;
+  const totalPct = maxTotal > 0 ? Math.round((total / maxTotal) * 100) : 0;
+
+  const teachingStatus = getStatusMeta(teachingPct, maxTeaching > 0);
+  const totalStatus = getStatusMeta(totalPct, maxTotal > 0);
+
+  const recentModules = (detailedAllocations || []).slice(0, 5);
+
+  if (!linkedProfile && !isLoadingProfile) {
+    return null;
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      {/* Capacity overview */}
+      <Card className="lg:col-span-2">
+        <CardHeader className="pb-4">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base font-semibold">
+              Workload Capacity
+            </CardTitle>
+            {currentYear && (
+              <Badge variant="outline" className="text-xs font-normal">
+                {currentYear.name}
+              </Badge>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {isLoading ? (
+            <div className="space-y-4">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : (
+            <>
+              {/* Teaching bar */}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="inline-block h-2.5 w-2.5 rounded-full bg-primary" />
+                    <span className="text-sm font-medium text-foreground">
+                      Teaching
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <teachingStatus.Icon
+                      className={`h-4 w-4 ${
+                        teachingStatus.status === 'over'
+                          ? 'text-destructive'
+                          : teachingStatus.status === 'warning'
+                            ? 'text-amber-500'
+                            : teachingStatus.status === 'optimal'
+                              ? 'text-emerald-500'
+                              : 'text-muted-foreground'
+                      }`}
+                    />
+                    <Badge
+                      variant={teachingStatus.badgeVariant}
+                      className={`text-xs ${teachingStatus.badgeClass}`}
+                    >
+                      {teachingStatus.label}
+                    </Badge>
+                  </div>
+                </div>
+                <CapacityBar
+                  label="Teaching hours"
+                  used={teaching}
+                  max={maxTeaching}
+                  colorClass={
+                    teachingStatus.status === 'over'
+                      ? 'bg-destructive'
+                      : teachingStatus.status === 'warning'
+                        ? 'bg-amber-500'
+                        : 'bg-primary'
+                  }
+                  tooltip="Hours allocated to teaching modules and groups"
+                />
+              </div>
+
+              <div className="border-t border-border/60" />
+
+              {/* Total bar */}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="inline-block h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                    <span className="text-sm font-medium text-foreground">
+                      Total (Teaching + Admin)
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <totalStatus.Icon
+                      className={`h-4 w-4 ${
+                        totalStatus.status === 'over'
+                          ? 'text-destructive'
+                          : totalStatus.status === 'warning'
+                            ? 'text-amber-500'
+                            : totalStatus.status === 'optimal'
+                              ? 'text-emerald-500'
+                              : 'text-muted-foreground'
+                      }`}
+                    />
+                    <Badge
+                      variant={totalStatus.badgeVariant}
+                      className={`text-xs ${totalStatus.badgeClass}`}
+                    >
+                      {totalStatus.label}
+                    </Badge>
+                  </div>
+                </div>
+                {/* Stacked bar */}
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground font-medium">
+                      Total contract
+                    </span>
+                    <span className="font-semibold text-foreground tabular-nums">
+                      {total}h{maxTotal > 0 ? ` / ${maxTotal}h` : ''}
+                    </span>
+                  </div>
+                  <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted flex">
+                    {maxTotal > 0 ? (
+                      <>
+                        <div
+                          className="h-full bg-primary transition-all duration-700 ease-out"
+                          style={{
+                            width: `${Math.min(100, Math.round((teaching / maxTotal) * 100))}%`,
+                          }}
+                        />
+                        <div
+                          className="h-full bg-amber-400 transition-all duration-700 ease-out"
+                          style={{
+                            width: `${Math.min(
+                              100 - Math.min(100, Math.round((teaching / maxTotal) * 100)),
+                              Math.round((admin / maxTotal) * 100)
+                            )}%`,
+                          }}
+                        />
+                      </>
+                    ) : (
+                      <div className="h-full w-0" />
+                    )}
+                  </div>
+                  <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <span className="inline-block h-2 w-2 rounded-sm bg-primary" />
+                      Teaching: {teaching}h
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span className="inline-block h-2 w-2 rounded-sm bg-amber-400" />
+                      Admin: {admin}h
+                    </span>
+                    {maxTotal > 0 && (
+                      <span className="ml-auto">
+                        {Math.max(0, maxTotal - total)}h remaining
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Profile meta */}
+              {linkedProfile && (
+                <div className="flex flex-wrap gap-x-6 gap-y-2 border-t border-border/60 pt-4 text-xs text-muted-foreground">
+                  <span>
+                    Contract:{' '}
+                    <span className="font-medium text-foreground">
+                      {linkedProfile.contract ?? '—'}
+                    </span>
+                  </span>
+                  <span>
+                    FTE:{' '}
+                    <span className="font-medium text-foreground">
+                      {linkedProfile.fte ?? '—'}
+                    </span>
+                  </span>
+                  <span>
+                    Max teaching:{' '}
+                    <span className="font-medium text-foreground">
+                      {maxTeaching ? `${maxTeaching}h` : '—'}
+                    </span>
+                  </span>
+                  <span>
+                    Total contract:{' '}
+                    <span className="font-medium text-foreground">
+                      {maxTotal ? `${maxTotal}h` : '—'}
+                    </span>
+                  </span>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Recent module allocations */}
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle className="text-base font-semibold">
+            Recent Allocations
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-3">
+              {[...Array(4)].map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full rounded-lg" />
+              ))}
+            </div>
+          ) : recentModules.length === 0 ? (
+            <div className="flex h-32 items-center justify-center rounded-lg border border-dashed text-sm text-muted-foreground">
+              No allocations yet
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {recentModules.map(({ allocation, module, group }, i) => {
+                const hours =
+                  typeof allocation.hoursOverride === 'number'
+                    ? allocation.hoursOverride
+                    : allocation.hoursComputed || 0;
+                return (
+                  <li
+                    key={i}
+                    className="flex items-center justify-between rounded-lg bg-muted/40 px-3 py-2.5 text-sm"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-medium text-foreground">
+                        {module?.code ?? '—'}{' '}
+                        <span className="font-normal text-muted-foreground">
+                          {module?.name ?? ''}
+                        </span>
+                      </p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        Group: {group?.name ?? '—'}
+                      </p>
+                    </div>
+                    <div className="ml-3 flex-shrink-0 text-right">
+                      <span
+                        className={`inline-block rounded-md px-2 py-0.5 text-xs font-semibold ${
+                          allocation.type === 'teaching'
+                            ? 'bg-primary/10 text-primary'
+                            : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+                        }`}
+                      >
+                        {hours}h
+                      </span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/dashboard/WorkloadSummaryCards.tsx
+++ b/src/components/dashboard/WorkloadSummaryCards.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useUser } from '@clerk/nextjs';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { useAcademicYear } from '@/components/providers/AcademicYearProvider';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { BookOpen, Briefcase, Clock, TrendingUp } from 'lucide-react';
+
+interface SummaryCardProps {
+  label: string;
+  value: string | number;
+  sublabel?: string;
+  icon: React.ComponentType<{ className?: string }>;
+  iconBg: string;
+  iconColor: string;
+  isLoading?: boolean;
+}
+
+function SummaryCard({
+  label,
+  value,
+  sublabel,
+  icon: Icon,
+  iconBg,
+  iconColor,
+  isLoading,
+}: SummaryCardProps) {
+  return (
+    <Card className="relative overflow-hidden">
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-muted-foreground leading-relaxed">
+              {label}
+            </p>
+            {isLoading ? (
+              <Skeleton className="mt-2 h-8 w-20" />
+            ) : (
+              <p className="mt-1 text-2xl font-bold tracking-tight text-foreground">
+                {value}
+              </p>
+            )}
+            {sublabel && !isLoading && (
+              <p className="mt-1 text-xs text-muted-foreground">{sublabel}</p>
+            )}
+            {sublabel && isLoading && (
+              <Skeleton className="mt-1 h-3 w-24" />
+            )}
+          </div>
+          <div className={`flex-shrink-0 rounded-xl p-2.5 ${iconBg}`}>
+            <Icon className={`h-5 w-5 ${iconColor}`} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function WorkloadSummaryCards() {
+  const { user } = useUser();
+  const { currentYear } = useAcademicYear();
+
+  // Find the linked lecturer profile for the current user
+  const staffList = useQuery(
+    api.staff.list,
+    user?.id ? { userId: user.id } : 'skip'
+  ) as Array<{
+    _id: string;
+    fullName: string;
+    userSubject?: string;
+    maxTeachingHours?: number;
+    totalContract?: number;
+  }> | undefined;
+
+  const linkedProfile = staffList?.find(
+    (s) => s.userSubject === user?.id
+  );
+
+  const totals = useQuery(
+    api.allocations.computeLecturerTotals,
+    linkedProfile?._id && currentYear?._id
+      ? {
+          lecturerId: linkedProfile._id as Id<'lecturer_profiles'>,
+          academicYearId: currentYear._id as Id<'academic_years'>,
+        }
+      : 'skip'
+  ) as
+    | {
+        allocatedTeaching: number;
+        allocatedAdmin: number;
+        allocatedTotal: number;
+      }
+    | undefined;
+
+  const adminAllocations = useQuery(
+    api.allocations.listAdminAllocations,
+    linkedProfile?._id && currentYear?._id
+      ? {
+          lecturerId: linkedProfile._id as Id<'lecturer_profiles'>,
+          academicYearId: currentYear._id as Id<'academic_years'>,
+        }
+      : 'skip'
+  ) as Array<{ allocation?: { hours?: number } }> | undefined;
+
+  const isLoadingProfile = staffList === undefined;
+  const isLoadingTotals = linkedProfile && totals === undefined;
+  const isLoading = isLoadingProfile || !!isLoadingTotals;
+
+  const teaching = totals?.allocatedTeaching ?? 0;
+  const adminStandalone = (adminAllocations || []).reduce(
+    (acc, r) => acc + (Number(r?.allocation?.hours) || 0),
+    0
+  );
+  const admin = (totals?.allocatedAdmin ?? 0) + adminStandalone;
+  const total = teaching + admin;
+  const maxTeaching = Number(linkedProfile?.maxTeachingHours) || 0;
+  const maxTotal = Number(linkedProfile?.totalContract) || 0;
+  const remaining = Math.max(0, maxTeaching - teaching);
+
+  const teachingPct =
+    maxTeaching > 0 ? Math.round((teaching / maxTeaching) * 100) : 0;
+
+  const cards: SummaryCardProps[] = [
+    {
+      label: 'Teaching Hours',
+      value: `${teaching}h`,
+      sublabel: maxTeaching
+        ? `of ${maxTeaching}h max (${teachingPct}% used)`
+        : 'No limit set',
+      icon: BookOpen,
+      iconBg: 'bg-primary/10',
+      iconColor: 'text-primary',
+      isLoading,
+    },
+    {
+      label: 'Admin Hours',
+      value: `${admin}h`,
+      sublabel: 'Administrative allocations',
+      icon: Briefcase,
+      iconBg: 'bg-amber-100 dark:bg-amber-900/30',
+      iconColor: 'text-amber-600 dark:text-amber-400',
+      isLoading,
+    },
+    {
+      label: 'Total Allocated',
+      value: `${total}h`,
+      sublabel: maxTotal
+        ? `of ${maxTotal}h contract (${maxTotal > 0 ? Math.round((total / maxTotal) * 100) : 0}% used)`
+        : 'No contract limit set',
+      icon: TrendingUp,
+      iconBg: 'bg-emerald-100 dark:bg-emerald-900/30',
+      iconColor: 'text-emerald-600 dark:text-emerald-400',
+      isLoading,
+    },
+    {
+      label: 'Teaching Remaining',
+      value: maxTeaching ? `${remaining}h` : '—',
+      sublabel: maxTeaching
+        ? `${remaining}h available to allocate`
+        : 'Set a contract to see remaining hours',
+      icon: Clock,
+      iconBg: remaining === 0 && maxTeaching > 0
+        ? 'bg-destructive/10'
+        : 'bg-secondary',
+      iconColor: remaining === 0 && maxTeaching > 0
+        ? 'text-destructive'
+        : 'text-secondary-foreground',
+      isLoading,
+    },
+  ];
+
+  if (!linkedProfile && !isLoadingProfile) {
+    return (
+      <div className="rounded-xl border border-dashed bg-muted/40 p-6 text-center text-sm text-muted-foreground">
+        No linked staff profile found. Ask an admin to link your account to a
+        lecturer profile to see your workload summary.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {cards.map((card) => (
+        <SummaryCard key={card.label} {...card} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Replaces the `DashboardPlaceholder` with a fully functional, responsive dashboard for WorkloadWizard.

## What's new

### `src/components/dashboard/WorkloadSummaryCards.tsx`
Four stat cards showing **Teaching Hours**, **Admin Hours**, **Total Allocated**, and **Teaching Remaining** — all pulled live from Convex (`computeLecturerTotals`, `listAdminAllocations`) for the user's linked lecturer profile and the active academic year. Shows skeleton loaders while data is fetching and a friendly empty state when no staff profile is linked.

### `src/components/dashboard/WorkloadStatusPanel.tsx`
A two-column panel with:
- **Capacity section** (2/3 width): individual progress bars for teaching and total (stacked teaching + admin) capacity with colour-coded status badges (`On track` / `Near capacity` / `Over capacity`), plus contract metadata.
- **Recent Allocations** (1/3 width): the 5 most recent module/group allocations with colour-coded hour chips.

### `src/components/dashboard/QuickLinksSection.tsx`
A responsive grid of 10 quick-link buttons (Staff Profile, Modules, Courses, Organisation, Academic Years, Audit Logs, Permissions, Reports, Account Settings, Support) — each with a labelled icon and short description. Grid adapts from 1 → 2 → 3 → 5 columns across breakpoints.

### `src/components/dashboard/DashboardContent.tsx`
Wrapper component using `StandardizedSidebarLayout` with a time-based greeting, active academic year badge in the header, and semantic `<section>` elements for each dashboard panel.

### `src/app/dashboard/page.tsx`
Swaps `DashboardPlaceholder` → `DashboardContent`.